### PR TITLE
Deinstall PCNTL signal handler when all listeners are removed.

### DIFF
--- a/src/MKraemer/ReactPCNTL/PCNTL.php
+++ b/src/MKraemer/ReactPCNTL/PCNTL.php
@@ -32,6 +32,45 @@ class PCNTL extends EventEmitter
     }
 
     /**
+     * Removes a signal handler
+     *
+     * @param int      $signo    The signal number
+     * @param callable $listener The listener
+     */
+    public function removeListener($signo, callable $listener) {
+        // call the parent's code
+        parent::removeListener($signo, $listener);
+
+        // if last listener removed, uninstall PCNTL signal handler
+        if (empty($this->listeners[$signo])) {
+            pcntl_signal($signo, SIG_DFL);
+        }
+    }
+
+    /**
+     * Removes all signal handlers
+     *
+     * @param int|null $signo    The signal number
+     */
+    public function removeAllListeners($signo = null) {
+        // prepare a list of signal numbers to deal with
+        $signoList = [];
+        if (!is_null($signo)) {
+            $signoList = [$signo];
+        } elseif (is_array($this->listeners)) {
+            $signoList = array_keys($this->listeners);
+        }
+
+        // call the parent's code
+        parent::removeAllListeners($signo);
+
+        // uninstall PCNTL signal handlers
+        foreach ($signoList as $realSigno) {
+            pcntl_signal($realSigno, SIG_DFL);
+        }
+    }
+
+    /**
      * Call signal handlers for pending signals
      */
     public function __invoke()


### PR DESCRIPTION
There is no need to have a signal handler installed when no listeners are registered for it.
This patch uninstalls the handler when the last listener is removed.

Note: This is a quick patch that I needed at work (for testing an unrelated bug) and did not have time to properly test. The overloaded methods seem to work, but I did not (and, sadly, will not) had time to add proper unit tests.